### PR TITLE
Fixes wrong header file being included

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ android {
     versionName "1.0"
     externalNativeBuild {
       cmake {
-        cppFlags "-fexceptions", "-frtti", "-std=c++1y", "-DONANDROID"
+        cppFlags "-fexceptions", "-frtti", "-std=c++1y", "-DONANDROID", "-DANDROID"
         arguments '-DANDROID_STL=c++_shared',
                   "-DREACT_NATIVE_VERSION=${REACT_NATIVE_VERSION}",
                   "-DNODE_MODULES_DIR=${nodeModules}",


### PR DESCRIPTION
Defines ANDROID in Gradle file
Fixes https://github.com/margelo/react-native-quick-crypto/issues/143#issuecomment-1460319948